### PR TITLE
refactor(machine): change invalid state error to match Go error style

### DIFF
--- a/fsm.go
+++ b/fsm.go
@@ -1,7 +1,6 @@
 package fsm
 
 import (
-	"errors"
 	"fmt"
 )
 
@@ -38,7 +37,7 @@ func (f *Machine) State() uint8 {
 func (f *Machine) Goto(state uint8) error {
 	t := f.transitions.Search(serialize(f.state, state))
 	if t == nil {
-		return errors.New(fmt.Sprintf("Transition %d to %d not permitted.", f.state, state))
+		return fmt.Errorf("can't transition from state %d to %d", f.state, state)
 	}
 
 	f.state = state

--- a/fsm_test.go
+++ b/fsm_test.go
@@ -32,7 +32,7 @@ func TestWorksNormally(t *testing.T) {
 	err := m.Goto(B)
 	assert.NotNil(t, err)
 	assert.Equal(t, C, m.State())
-	assert.Equal(t, "Transition 2 to 1 not permitted.", err.Error())
+	assert.Equal(t, "can't transition from state 2 to 1", err.Error())
 }
 
 func TestAddsHandler(t *testing.T) {


### PR DESCRIPTION
Also change to use `fmt.Errorf` instead of `errors.New(fmt.Sprintf(...))`.

See https://github.com/golang/go/wiki/Errors.